### PR TITLE
Unconditionally define _GNU_SOURCE

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,7 +1,5 @@
 
-#if defined(__gnu_linux__) || defined(__CYGWIN__)
 #define _GNU_SOURCE
-#endif
 
 #include <fcntl.h>
 #include <limits.h>

--- a/pty.c
+++ b/pty.c
@@ -1,7 +1,5 @@
 
-#if defined(__gnu_linux__) || defined(__CYGWIN__)
 #define _GNU_SOURCE
-#endif
 
 #include <string.h>
 #include <stdio.h>

--- a/server.c
+++ b/server.c
@@ -1,7 +1,5 @@
 
-#if defined(__gnu_linux__) || defined(__CYGWIN__)
 #define _GNU_SOURCE
-#endif
 
 #include <assert.h>
 #include <fcntl.h>


### PR DESCRIPTION
uClibc also uses `_GNU_SOURCE` to expose glibc compatible API extensions. But toolchain built with uClibc don't define `__gnu_linux__`. This leads to implicit declaration warnings at build time. With GCC 14 these warnings become errors by default.

For example:

~~~
.../sexpect-2.3.14/server.c: In function 'expect_exact': .../sexpect-2.3.14/server.c:630:17: error: implicit declaration of function 'strcasestr'; did you mean 'strcasecmp'?
  [-Wimplicit-function-declaration]
  630 |         found = strcasestr(g.expbuf, g.conn.pass.pattern);
      |                 ^~~~~~~~~~
      |                 strcasecmp
~~~

Define `_GNU_SOURCE` unconditionally to fix the build.